### PR TITLE
Add stage for building prod to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,17 @@ exit $?
       }
     }
 
+    stage('Build Prod') {
+      when {
+        // Deploy only when the branch being built is master.
+        expression { env.BRANCH_NAME == 'master' }
+      }
+      steps {
+        sh('rm -rf dist/')
+        sh('npm run build')
+      }
+    }
+
     stage('Deploy Prod') {
       when {
         // Deploy only when the branch being built is master.


### PR DESCRIPTION
I noticed that the same build was being deployed to development and
production, causing the production website to point to the development
API. This should fix the problem.