### PR TITLE
Make Hadith component a static component

### DIFF
--- a/src/components/HadithWidget.js
+++ b/src/components/HadithWidget.js
@@ -14,7 +14,7 @@ const styles = {
   }
 };
 
-class Hadith extends React.Component {
+class HadithWidget extends React.Component {
   state = {
     hadith: null
   };
@@ -31,8 +31,7 @@ class Hadith extends React.Component {
   }
 
   render() {
-    const { classes } = this.props;
-    const { hadith } = this.state;
+    const { classes, hadith } = this.props;
 
     if (!hadith) {
       return <Card className={classes.card} />;
@@ -41,7 +40,7 @@ class Hadith extends React.Component {
     return (
       <Card className={classes.card}>
         <CardContent>
-          <Typography>{hadith != null ? hadith.text : ""}</Typography>
+          <Typography>{hadith.text}</Typography>
         </CardContent>
         <CardActions>
           <Button component={Link} to={`/hadiths/${hadith.id}`} size="small">
@@ -53,11 +52,11 @@ class Hadith extends React.Component {
   }
 }
 
-Hadith.propTypes = {
+HadithWidget.propTypes = {
   classes: PropTypes.object.isRequired,
-  hadithId: PropTypes.string.isRequired
+  hadith: PropTypes.object.isRequired
 };
 
-const comp = withStyles(styles)(Hadith);
+const comp = withStyles(styles)(HadithWidget);
 
-export { comp as Hadith };
+export { comp as HadithWidget };

--- a/src/components/HadithWidget.test.js
+++ b/src/components/HadithWidget.test.js
@@ -1,0 +1,21 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { MemoryRouter } from "react-router";
+import { HadithWidget } from "./HadithWidget";
+
+it("renders without crashing", () => {
+  const div = document.createElement("div");
+
+  const hadith = {
+    id: 1,
+    text: "text"
+  };
+
+  ReactDOM.render(
+    <MemoryRouter>
+      <HadithWidget hadith={hadith} />
+    </MemoryRouter>,
+    div
+  );
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/src/containers/HomePage/HomePage.js
+++ b/src/containers/HomePage/HomePage.js
@@ -1,0 +1,29 @@
+import React from "react";
+import HomePageView from "./HomePageView";
+import axios from "axios";
+
+export default class HomePage extends React.Component {
+  state = {
+    hadith: null
+  };
+
+  loadRandomHadith() {
+    axios
+      .get(`http://api-dev.hadithhouse.net/apis/hadiths/random`)
+      .then(response => {
+        this.setState({
+          hadith: response.data
+        });
+      });
+  }
+
+  componentDidMount() {
+    this.loadRandomHadith();
+  }
+
+  render() {
+    const { hadith } = this.state;
+
+    return <HomePageView hadith={hadith} />;
+  }
+}

--- a/src/containers/HomePage/HomePageView.js
+++ b/src/containers/HomePage/HomePageView.js
@@ -1,0 +1,23 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { HadithWidget } from "../../components/HadithWidget";
+
+export default class HomePageView extends React.Component {
+  render() {
+    const { hadith } = this.props;
+
+    if (!hadith) {
+      return <div />;
+    }
+
+    return (
+      <div>
+        <HadithWidget hadith={hadith} />
+      </div>
+    );
+  }
+}
+
+HomePageView.propTypes = {
+  hadith: PropTypes.object
+};

--- a/src/containers/HomePage/HomePageView.test.js
+++ b/src/containers/HomePage/HomePageView.test.js
@@ -1,0 +1,19 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import HomePageView from "./HomePageView";
+import { MemoryRouter } from "react-router";
+
+it("renders without crashing", () => {
+  const div = document.createElement("div");
+  const hadith = {
+    id: 1,
+    text: "test"
+  };
+  ReactDOM.render(
+    <MemoryRouter>
+      <HomePageView hadith={hadith} />
+    </MemoryRouter>,
+    div
+  );
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/src/containers/HomePage/index.js
+++ b/src/containers/HomePage/index.js
@@ -1,14 +1,6 @@
 import React from "react";
 import HomeIcon from "@material-ui/icons/Home";
-import { Hadith } from "../../components/Hadith";
-
-export function HomePage() {
-  return (
-    <div>
-      <Hadith hadithId="random" />
-    </div>
-  );
-}
+import HomePage from "./HomePage";
 
 HomePage.pageInfo = {
   path: "/",
@@ -16,3 +8,5 @@ HomePage.pageInfo = {
   title: "الصفحة الرئيسية",
   showInNavDrawer: true
 };
+
+export { HomePage };

--- a/src/containers/HomePage/test.js
+++ b/src/containers/HomePage/test.js
@@ -1,9 +1,0 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import { HomePage } from "./";
-
-it("renders without crashing", () => {
-  const div = document.createElement("div");
-  ReactDOM.render(<HomePage />, div);
-  ReactDOM.unmountComponentAtNode(div);
-});


### PR DESCRIPTION
To follow react best practices, I changed `Hadith` component to be
static (presentational) component (and renamed it to `HadithWidget`).
Then, I changed the `HomePage` to load a random hadith instead of
assuming the `HadithWidget` component to load it.