### PR TITLE
Remove issueCommentTrigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,6 @@
 pipeline {
   agent any
 
-  pipelineTriggers {
-    issueCommentTrigger('.*test this please.*')
-  }
-
   stages {
     stage('Install Node modules') {
       steps {


### PR DESCRIPTION
It caused the build to fail after rebuilding the Jenkins server:

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 7: Invalid trigger type "issueCommentTrigger". Valid trigger types: [upstream, cron, githubPush, pollSCM] @ line 7, column 5.
       issueCommentTrigger('.*test this please.*')
```

From the documentation, it seems there are some requirements:

https://github.com/jenkinsci/pipeline-github-plugin#issuecommenttrigger

so removing it for now.